### PR TITLE
修复 wrangler 配置文件占位符替换时序问题

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -44,28 +44,9 @@ jobs:
 
       - name: 📡 Disable wrangler telemetry
         working-directory: ./mail-worker
-        run: npx wrangler telemetry disable -c wrangler-action.toml
+        run: npx wrangler telemetry disable
 
-      - name: 🤫 Set Worker secrets (ignore if already exists)
-        working-directory: ./mail-worker
-        run: |
-          WORKER_NAME="cloud-mail"
-          CONFIG_FILE="wrangler-action.toml"
-          echo "🔒 Attempting to create/update secrets using '$CONFIG_FILE'."
-
-          for VAR in DOMAIN ADMIN JWT_SECRET; do
-            if [ -n "${!VAR}" ]; then
-              VAR_LOWER=$(echo "$VAR" | tr '[:upper:]' '[:lower:]')
-              echo ">> Processing secret: '$VAR_LOWER'"
-              (echo "${!VAR}" | npx wrangler secret put "$VAR_LOWER" --name "$WORKER_NAME" -c "$CONFIG_FILE") || true
-            else
-              echo "⚠️ Warning: GitHub Secret '$VAR' is not set. Skipping."
-            fi
-          done
-          
-          echo "✨ Secret processing complete."
-
-      - name: 🛠️ Prepare Config and Deploy
+      - name: 🛠️ Prepare Config, Set Secrets and Deploy
         id: deploy
         working-directory: ./mail-worker
         run: |
@@ -84,20 +65,37 @@ jobs:
           sed -i "s|\${KV_NAMESPACE_ID}|${KV_NAMESPACE_ID}|g" "$CONFIG_FILE"
           sed -i "s|\${R2_BUCKET_NAME}|${R2_BUCKET_NAME}|g" "$CONFIG_FILE"
 
+          echo "🔍 Debug: Checking configuration after replacement..."
+          echo "R2_BUCKET_NAME value: '$R2_BUCKET_NAME'"
+          echo "R2 bucket configuration in $CONFIG_FILE:"
+          grep -A 2 -B 2 "bucket_name" "$CONFIG_FILE" || true
+
+          echo "🔒 Setting Worker secrets..."
+          WORKER_NAME="cloud-mail"
+          for VAR in DOMAIN ADMIN JWT_SECRET; do
+            if [ -n "${!VAR}" ]; then
+              VAR_LOWER=$(echo "$VAR" | tr '[:upper:]' '[:lower:]')
+              echo ">> Processing secret: '$VAR_LOWER'"
+              (echo "${!VAR}" | npx wrangler secret put "$VAR_LOWER" --name "$WORKER_NAME" -c "$CONFIG_FILE") || true
+            else
+              echo "⚠️ Warning: GitHub Secret '$VAR' is not set. Skipping."
+            fi
+          done
+
           echo "🚀 Configuration updated. Starting deployment..."
           npx wrangler deploy -c "$CONFIG_FILE" | grep -v "https://.*\.workers\.dev" || true
           echo "✅ Deployment command executed."
 
       - name: 🗄️ Initialize Database (if INIT_URL is set)
-        if: steps.deploy.outputs.deployment_skipped == 'false'
+        if: ${{ steps.deploy.outputs.deployment_skipped == 'false' }}
         run: |
           if [ -z "$INIT_URL" ]; then
             echo "✅ Deployment successful. INIT_URL not set, skipping initialization."
             exit 0
           fi
           
-          echo "⏳ Waiting 10 秒之前 before checking initialization status..."
-          sleep 10
+          echo "⏳ Waiting 15 秒之前 before checking initialization status..."
+          sleep 15
           
           HTTP_CODE=$(curl -s -w "%{http_code}" -o response.txt "$INIT_URL")
           RESPONSE_BODY=$(cat response.txt)


### PR DESCRIPTION
- 移除 telemetry 命令的配置文件参数避免在替换前读取配置
- 重新组织工作流步骤，确保配置文件占位符替换在所有 wrangler 命令之前执行
- 添加调试信息显示 R2_BUCKET_NAME 值和配置文件内容
- 修复 R2 bucket name 验证错误
- 调整数据库初始化等待时间从 10 秒增加到 15 秒