### PR TITLE
修复在不支持navigator.clipboard时写入剪贴板报错

### DIFF
--- a/mail-vue/src/layout/account/index.vue
+++ b/mail-vue/src/layout/account/index.vue
@@ -124,6 +124,7 @@ import {Icon} from "@iconify/vue";
 import {nextTick, reactive, ref, watch} from "vue";
 import {accountList, accountAdd, accountDelete, accountSetName} from "@/request/account.js";
 import {isEmail} from "@/utils/verify-utils.js";
+import {copyText} from "@/utils/clipboard-utils.js";
 import {useSettingStore} from "@/store/setting.js";
 import {useAccountStore} from "@/store/account.js";
 import {useUserStore} from "@/store/user.js";
@@ -286,7 +287,7 @@ function add() {
 
 async function copyAccount(account) {
   try {
-    await navigator.clipboard.writeText(account);
+    await copyText(account);
     ElMessage({
       message: t('copySuccessMsg'),
       type: 'success',

--- a/mail-vue/src/layout/header/index.vue
+++ b/mail-vue/src/layout/header/index.vue
@@ -86,6 +86,7 @@ import {computed, ref} from "vue";
 import {useSettingStore} from "@/store/setting.js";
 import { hasPerm } from "@/perm/perm.js"
 import {useI18n} from "vue-i18n";
+import {copyText} from "@/utils/clipboard-utils.js";
 
 const { t } = useI18n();
 const route = useRoute();
@@ -149,7 +150,7 @@ const sendCount = computed(() => {
 
 async function copyEmail(email) {
   try {
-    await navigator.clipboard.writeText(email);
+    await copyText(email);
     ElMessage({
       message: t('copySuccessMsg'),
       type: 'success',

--- a/mail-vue/src/utils/clipboard-utils.js
+++ b/mail-vue/src/utils/clipboard-utils.js
@@ -1,0 +1,48 @@
+export async function copyText(text) {
+    const value = text == null ? '' : String(text)
+
+    if (typeof navigator !== 'undefined' && typeof navigator.clipboard?.writeText === 'function') {
+        return await navigator.clipboard.writeText(value)
+    }
+
+    return new Promise((resolve, reject) => {
+        try {
+            const ta = document.createElement('textarea')
+            ta.value = value
+            ta.setAttribute('readonly', '')
+
+            // 避免页面抖动、滚动与可视影响
+            const s = ta.style
+            s.position = 'fixed'
+            s.top = '0'
+            s.left = '0'
+            s.width = '1px'
+            s.height = '1px'
+            s.padding = '0'
+            s.border = '0'
+            s.outline = 'none'
+            s.boxShadow = 'none'
+            s.background = 'transparent'
+            s.opacity = '0'
+
+            document.body.appendChild(ta)
+
+            // 选择内容
+            ta.focus()
+            ta.select()
+
+            let ok = false
+            try {
+                ok = document.execCommand('copy')
+            } catch (err) {
+                return reject(err)
+            } finally {
+                document.body.removeChild(ta)
+            }
+            ok ? resolve() : reject(new Error('Copy command unsuccessful'))
+        } catch (e) {
+            reject(e)
+        }
+    })
+}
+

--- a/mail-vue/src/views/reg-key/index.vue
+++ b/mail-vue/src/views/reg-key/index.vue
@@ -105,6 +105,7 @@ import { getTextWidth } from "@/utils/text.js";
 import dayjs from "dayjs";
 import {tzDayjs} from "@/utils/day.js";
 import {useI18n} from "vue-i18n";
+import {copyText} from "@/utils/clipboard-utils.js";
 
 defineOptions({
   name: 'reg-key'
@@ -254,7 +255,7 @@ function getList(showLoading = false) {
 
 async function copyCode(code) {
   try {
-    await navigator.clipboard.writeText(code);
+    await copyText(code);
     ElMessage({
       message: t('copySuccessMsg'),
       type: 'success',


### PR DESCRIPTION
在非HTTPS下不支持使用navigator.clipboard，回退到使用document.execCommand('copy')